### PR TITLE
[1.5.0][Berlin] Update Evaluatory MySQL Data Source Helm Chart for Open Banking

### DIFF
--- a/mysql-ob/values.yaml
+++ b/mysql-ob/values.yaml
@@ -522,6 +522,16 @@ mysql:
         GRANT ALL ON OPENBANK_APIMGT_STATS_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
         GRANT ALL ON OPENBANK_APIMGT_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
 
+        USE OPENBANK_APIMGT_STATS_DB;
+
+        CREATE TABLE IF NOT EXISTS AM_USAGE_UPLOADED_FILES (
+        FILE_NAME varchar(255) NOT NULL,
+        FILE_TIMESTAMP TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FILE_PROCESSED tinyint(1) DEFAULT 0,
+        FILE_CONTENT MEDIUMBLOB DEFAULT NULL,
+        PRIMARY KEY (FILE_NAME, FILE_TIMESTAMP)
+        );
+
         USE OPENBANK_APIMGT_DB;
 
         -- Start of IDENTITY Tables--
@@ -3134,240 +3144,6 @@ mysql:
                     UM_TENANT_ID INTEGER DEFAULT 0,
         			PRIMARY KEY (UM_ID, UM_TENANT_ID)
         )ENGINE INNODB;
-    mysql_openbank_mbstoredb.sql: |-
-        -- WSO2 Message Broker MySQL Database schema --
-
-        -- Start of Message Store Tables --
-
-        DROP DATABASE IF EXISTS OPENBANK_MB_STORE_DB;
-
-        CREATE DATABASE OPENBANK_MB_STORE_DB;
-
-        GRANT ALL ON OPENBANK_MB_STORE_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
-
-        USE OPENBANK_MB_STORE_DB;
-
-        CREATE TABLE IF NOT EXISTS MB_QUEUE_MAPPING (
-                        QUEUE_ID INTEGER AUTO_INCREMENT,
-                        QUEUE_NAME VARCHAR(512) UNIQUE NOT NULL,
-                        PRIMARY KEY (QUEUE_ID, QUEUE_NAME)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_METADATA (
-                        MESSAGE_ID BIGINT,
-                        QUEUE_ID INTEGER,
-                        DLC_QUEUE_ID INTEGER NOT NULL,
-                        MESSAGE_METADATA VARBINARY(65500) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID, QUEUE_ID),
-                        FOREIGN KEY (QUEUE_ID) REFERENCES MB_QUEUE_MAPPING (QUEUE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE INDEX MB_METADATA_QUEUE_ID_INDEX ON MB_METADATA (QUEUE_ID) USING HASH;
-
-        CREATE TABLE IF NOT EXISTS MB_CONTENT (
-                        MESSAGE_ID BIGINT,
-                        CONTENT_OFFSET INTEGER,
-                        MESSAGE_CONTENT VARBINARY(65500) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID,CONTENT_OFFSET),
-                        FOREIGN KEY (MESSAGE_ID) REFERENCES MB_METADATA (MESSAGE_ID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_EXPIRATION_DATA (
-                        MESSAGE_ID BIGINT UNIQUE,
-                        EXPIRATION_TIME BIGINT,
-                        DLC_QUEUE_ID INTEGER NOT NULL,
-                        MESSAGE_DESTINATION VARCHAR(512) NOT NULL,
-                        FOREIGN KEY (MESSAGE_ID) REFERENCES MB_METADATA (MESSAGE_ID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_RETAINED_METADATA (
-                        TOPIC_ID INTEGER,
-                        TOPIC_NAME VARCHAR(512) NOT NULL,
-                        MESSAGE_ID BIGINT NOT NULL,
-                        MESSAGE_METADATA VARBINARY(65000) NOT NULL,
-                        PRIMARY KEY (TOPIC_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_DTX_XID (
-                        INTERNAL_XID BIGINT UNIQUE NOT NULL,
-                        NODE_ID VARCHAR(512) NOT NULL,
-                        FORMAT_CODE BIGINT NOT NULL,
-                        GLOBAL_ID VARBINARY(260), -- AMQP-10 vbin8 type
-                        BRANCH_ID VARBINARY(260), -- AMQP-10 vbin8 type
-                        PRIMARY KEY (INTERNAL_XID, NODE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_DTX_ENQUEUE_RECORD (
-                        INTERNAL_XID BIGINT NOT NULL,
-                        MESSAGE_ID BIGINT NOT NULL,
-                        MESSAGE_METADATA VARBINARY(65000) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID),
-                        FOREIGN KEY (INTERNAL_XID) REFERENCES MB_DTX_XID (INTERNAL_XID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_DTX_DEQUEUE_RECORD (
-                        INTERNAL_XID BIGINT NOT NULL,
-                        MESSAGE_ID BIGINT NOT NULL,
-                        QUEUE_NAME VARCHAR(512) NOT NULL,
-                        MESSAGE_METADATA VARBINARY(65000) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID),
-                        FOREIGN KEY (INTERNAL_XID) REFERENCES MB_DTX_XID (INTERNAL_XID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_DTX_ENQUEUE_CONTENT (
-                        MESSAGE_ID BIGINT NOT NULL,
-                        INTERNAL_XID BIGINT NOT NULL,
-                        CONTENT_OFFSET INTEGER NOT NULL,
-                        MESSAGE_CONTENT VARBINARY(65500) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID, CONTENT_OFFSET),
-                        FOREIGN KEY (MESSAGE_ID) REFERENCES MB_DTX_ENQUEUE_RECORD (MESSAGE_ID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_DTX_DEQUEUE_CONTENT (
-                        INTERNAL_XID BIGINT NOT NULL,
-                        MESSAGE_ID BIGINT NOT NULL,
-                        CONTENT_OFFSET INTEGER NOT NULL,
-                        MESSAGE_CONTENT VARBINARY(65500) NOT NULL,
-                        PRIMARY KEY (MESSAGE_ID, CONTENT_OFFSET),
-                        FOREIGN KEY (MESSAGE_ID) REFERENCES MB_DTX_DEQUEUE_RECORD (MESSAGE_ID)
-                        ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        -- End of Message Store Tables --
-
-        -- Start of Andes Context Store Tables --
-
-        CREATE TABLE IF NOT EXISTS MB_DURABLE_SUBSCRIPTION (
-                                SUBSCRIPTION_ID VARCHAR(512) NOT NULL,
-                                DESTINATION_IDENTIFIER VARCHAR(512) NOT NULL,
-                                SUBSCRIPTION_DATA VARCHAR(2048) NOT NULL
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_NODE (
-                                NODE_ID VARCHAR(512) NOT NULL,
-                                NODE_DATA VARCHAR(2048) NOT NULL,
-                                PRIMARY KEY(NODE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_EXCHANGE (
-                                EXCHANGE_NAME VARCHAR(512) NOT NULL,
-                                EXCHANGE_DATA VARCHAR(2048) NOT NULL,
-                                PRIMARY KEY(EXCHANGE_NAME)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_QUEUE (
-                                QUEUE_NAME VARCHAR(512) NOT NULL,
-                                QUEUE_DATA VARCHAR(2048) NOT NULL,
-                                PRIMARY KEY(QUEUE_NAME)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_BINDING (
-                                EXCHANGE_NAME VARCHAR(512) NOT NULL,
-                                QUEUE_NAME VARCHAR(512) NOT NULL,
-                                BINDING_DETAILS VARCHAR(2048) NOT NULL,
-                                FOREIGN KEY (EXCHANGE_NAME) REFERENCES MB_EXCHANGE (EXCHANGE_NAME),
-                                FOREIGN KEY (QUEUE_NAME) REFERENCES MB_QUEUE (QUEUE_NAME)
-                                ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_QUEUE_COUNTER (
-                                QUEUE_NAME VARCHAR(512) NOT NULL,
-                                MESSAGE_COUNT BIGINT,
-                                PRIMARY KEY (QUEUE_NAME)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_SLOT (
-                                SLOT_ID bigint(11) NOT NULL AUTO_INCREMENT,
-                                START_MESSAGE_ID bigint(20) NOT NULL,
-                                END_MESSAGE_ID bigint(20) NOT NULL,
-                                STORAGE_QUEUE_NAME varchar(512) NOT NULL,
-                                SLOT_STATE tinyint(4) NOT NULL DEFAULT '1',
-                                ASSIGNED_NODE_ID varchar(512) DEFAULT NULL,
-                                ASSIGNED_QUEUE_NAME varchar(512) DEFAULT NULL,
-                                PRIMARY KEY (SLOT_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        -- Default value '1' for SLOT_STATE stands for CREATED state of slot
-
-        CREATE INDEX MB_SLOT_MESSAGE_ID_INDEX ON MB_SLOT (START_MESSAGE_ID, END_MESSAGE_ID) USING HASH;
-
-        CREATE INDEX MB_SLOT_QUEUE_INDEX ON MB_SLOT (STORAGE_QUEUE_NAME) USING HASH;
-
-        CREATE TABLE IF NOT EXISTS MB_SLOT_MESSAGE_ID (
-                                QUEUE_NAME varchar(512) NOT NULL,
-                                MESSAGE_ID bigint(20) NOT NULL,
-                                PRIMARY KEY (QUEUE_NAME,MESSAGE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_NODE_TO_LAST_PUBLISHED_ID (
-                                NODE_ID varchar(512) NOT NULL,
-                                MESSAGE_ID bigint(20) NOT NULL,
-                                PRIMARY KEY (NODE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_QUEUE_TO_LAST_ASSIGNED_ID (
-                                QUEUE_NAME varchar(512) NOT NULL,
-                                MESSAGE_ID bigint(20) NOT NULL,
-                                PRIMARY KEY (QUEUE_NAME)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_MSG_STORE_STATUS (
-                                NODE_ID VARCHAR(512) NOT NULL,
-                                TIME_STAMP BIGINT,
-                                PRIMARY KEY (NODE_ID, TIME_STAMP)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_RETAINED_CONTENT (
-                                MESSAGE_ID BIGINT,
-                                CONTENT_OFFSET INT,
-                                MESSAGE_CONTENT VARBINARY(65500) NOT NULL,
-                                PRIMARY KEY (MESSAGE_ID,CONTENT_OFFSET)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_COORDINATOR_HEARTBEAT (
-                                ANCHOR INT NOT NULL,
-                                NODE_ID VARCHAR(512) NOT NULL,
-                                LAST_HEARTBEAT BIGINT NOT NULL,
-                                THRIFT_HOST VARCHAR(512) NOT NULL,
-                                THRIFT_PORT INT NOT NULL,
-                                PRIMARY KEY (ANCHOR)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_NODE_HEARTBEAT (
-                                NODE_ID VARCHAR(512) NOT NULL,
-                                LAST_HEARTBEAT BIGINT NOT NULL,
-                                IS_NEW_NODE TINYINT NOT NULL,
-                                CLUSTER_AGENT_HOST VARCHAR(512) NOT NULL,
-                                CLUSTER_AGENT_PORT INT NOT NULL,
-                                PRIMARY KEY (NODE_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_MEMBERSHIP (
-                                EVENT_ID BIGINT NOT NULL AUTO_INCREMENT,
-                                NODE_ID VARCHAR(512) NOT NULL,
-                                CHANGE_TYPE tinyint(4) NOT NULL,
-                                CHANGED_MEMBER_ID VARCHAR(512) NOT NULL,
-                                PRIMARY KEY (EVENT_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        CREATE TABLE IF NOT EXISTS MB_CLUSTER_EVENT (
-                                EVENT_ID BIGINT NOT NULL AUTO_INCREMENT,
-                                ORIGINATED_NODE_ID VARCHAR(512) NOT NULL,
-                                DESTINED_NODE_ID VARCHAR(512) NOT NULL,
-                                EVENT_ARTIFACT VARCHAR(25) NOT NULL,
-                                EVENT_TYPE VARCHAR(25) NOT NULL,
-                                EVENT_DETAILS VARCHAR(1024) NOT NULL,
-                                EVENT_DESCRIPTION VARCHAR(1024),
-                                PRIMARY KEY (EVENT_ID)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-        -- End of Andes Context Store Tables --
-
     mysql_openbank_userdb.sql: |-
         DROP DATABASE IF EXISTS OPENBANK_USER_DB;
 
@@ -3854,3 +3630,22 @@ mysql:
                     UM_TENANT_ID INTEGER DEFAULT 0,
         			PRIMARY KEY (UM_ID, UM_TENANT_ID)
         )ENGINE INNODB;
+
+    mysql_openbanking_business_intelligence.sql: |-
+        DROP DATABASE IF EXISTS OPENBANK_GEOLOCATION_DB;
+        DROP DATABASE IF EXISTS OPENBANK_REPORTING_STATS_DB;
+        DROP DATABASE IF EXISTS OPENBANK_REPORTING_SUMMARIZED_DB;
+        DROP DATABASE IF EXISTS OPENBANK_BUSINESS_RULES_DB;
+        DROP DATABASE IF EXISTS OPENBANK_PERMISSIONS_DB;
+
+        CREATE DATABASE OPENBANK_GEOLOCATION_DB;
+        CREATE DATABASE OPENBANK_REPORTING_STATS_DB;
+        CREATE DATABASE OPENBANK_REPORTING_SUMMARIZED_DB;
+        CREATE DATABASE OPENBANK_BUSINESS_RULES_DB;
+        CREATE DATABASE OPENBANK_PERMISSIONS_DB;
+
+        GRANT ALL ON OPENBANK_GEOLOCATION_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
+        GRANT ALL ON OPENBANK_REPORTING_STATS_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
+        GRANT ALL ON OPENBANK_REPORTING_SUMMARIZED_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
+        GRANT ALL ON OPENBANK_BUSINESS_RULES_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
+        GRANT ALL ON OPENBANK_PERMISSIONS_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';


### PR DESCRIPTION
## Purpose
> This PR removes the unnecessary MB store database and updates the database init scripts with database and schema required for Business Intelligence support.

## Goals
> Update Evaluatory MySQL Data Source Helm Chart for Open Banking

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`