### PR TITLE
[1.5.0][Berlin][Pattern-2] Fix Incorrect MySQL Connection URL Error

### DIFF
--- a/ob-pattern-2/templates/NOTES.txt
+++ b/ob-pattern-2/templates/NOTES.txt
@@ -45,7 +45,7 @@ API Manager and Key Manager.
    If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
    hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
-   <EXTERNAL-IP> {{ .Values.wso2.deployment.ob.am.ingress.management.hostname }} {{ .Values.wso2.deployment.ob.am.ingress.gateway.hostname }} {{ .Values.wso2.deployment.ob.km.ingress.hostname }}
+   <EXTERNAL-IP> {{ .Values.wso2.deployment.ob.am.ingress.management.hostname }} {{ .Values.wso2.deployment.ob.am.ingress.gateway.hostname }} {{ .Values.wso2.deployment.ob.km.ingress.hostname }} {{ .Values.wso2.deployment.ob.bi.dashboard.ingress.hostname }}
 
 3. Navigate to the consoles in your browser of choice.
 

--- a/ob-pattern-2/templates/ob-bi/dashboard/wso2ob-pattern-2-ob-bi-dashboard-conf.yaml
+++ b/ob-pattern-2/templates/ob-bi/dashboard/wso2ob-pattern-2-ob-bi-dashboard-conf.yaml
@@ -276,7 +276,7 @@ data:
           type: RDBMS
           configuration:
             {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.businessRules.name }}?autoReconnect=true&amp;useSSL=false'
+            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.businessRules.name }}?autoReconnect=true&useSSL=false'
             {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
             jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.businessRules.name }};SendStringParametersAsUnicode=false'
             {{- end }}
@@ -360,7 +360,7 @@ data:
           type: RDBMS
           configuration:
             {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }}?autoReconnect=true&amp;useSSL=false'
+            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }}?autoReconnect=true&useSSL=false'
             {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
             jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }};SendStringParametersAsUnicode=false'
             {{- end }}
@@ -384,7 +384,7 @@ data:
           type: RDBMS
           configuration:
             {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }}?autoReconnect=true&amp;useSSL=false'
+            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }}?autoReconnect=true&useSSL=false'
             {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
             jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }};SendStringParametersAsUnicode=false'
             {{- end }}
@@ -407,7 +407,7 @@ data:
           type: RDBMS
           configuration:
             {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }}?autoReconnect=true&amp;useSSL=false'
+            jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }}?autoReconnect=true&useSSL=false'
             {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
             jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }};SendStringParametersAsUnicode=false'
             {{- end }}

--- a/ob-pattern-2/templates/ob-bi/worker/wso2ob-pattern-2-ob-bi-worker-conf.yaml
+++ b/ob-pattern-2/templates/ob-bi/worker/wso2ob-pattern-2-ob-bi-worker-conf.yaml
@@ -404,7 +404,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.permissions.name }};SendStringParametersAsUnicode=false'
               {{- end }}
@@ -446,7 +446,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.geoLocation.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.geoLocation.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.geoLocation.name }};SendStringParametersAsUnicode=false'
               {{- end }}
@@ -469,7 +469,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.apiManagementStats.name }};SendStringParametersAsUnicode=false'
               {{- end }}
@@ -511,7 +511,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.openBanking.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.openBanking.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.openBanking.name }};SendStringParametersAsUnicode=false'
               {{- end }}
@@ -534,7 +534,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.reportingStats.name }};SendStringParametersAsUnicode=false'
               {{- end }}
@@ -557,7 +557,7 @@ data:
             type: RDBMS
             configuration:
               {{- if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mysql" }}
-              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingSummarized.name }}?autoReconnect=true&amp;useSSL=false'
+              jdbcUrl: 'jdbc:mysql://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }}/{{ .Values.wso2.deployment.ob.config.datasources.databases.reportingSummarized.name }}?autoReconnect=true&useSSL=false'
               {{- else if eq .Values.wso2.deployment.ob.config.datasources.rdbms.type "mssql" }}
               jdbcUrl: 'jdbc:sqlserver://{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.hostname }}:{{ .Values.wso2.deployment.ob.config.datasources.rdbms.server.port }};databaseName={{ .Values.wso2.deployment.ob.config.datasources.databases.reportingSummarized.name }};SendStringParametersAsUnicode=false'
               {{- end }}


### PR DESCRIPTION
## Purpose
> OB BI product profiles were failing to connect with the evaluatory MySQL server deployment due to an incorrectly defined `&` character within the connection URLs.

## Goals
> Fix incorrect MySQL connection URL error

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`
> Product Docker images from WSO2 Private Docker Registry